### PR TITLE
Set framerate for pixelate animation and start with bigger chunks

### DIFF
--- a/src/fraqture/pixelate.clj
+++ b/src/fraqture/pixelate.clj
@@ -31,7 +31,8 @@
   (shuffle (pixelate (* pixel-width mult) (* pixel-height mult))))
 
 (defn setup [options]
-  (let [pixel-multiplier 1]
+  (q/frame-rate 30)
+  (let [pixel-multiplier 3]
     (-> (stream/get-image!) (q/load-image) (q/image 0 0 (q/width) (q/height)))
     { :pixel-multiplier pixel-multiplier
       :options options


### PR DESCRIPTION
### Why?
Addresses https://github.com/smashingboxes/fraqture/issues/50
Because the `pixelate` animation was sometimes waaaaaaay too long.

### What Changed?
`pixelate` was running at the frame rate set by the animation preceding it

It would run anywhere from 30 seconds to several minutes
The frame rate is now explicitly set in `pixelate` and it now runs at a consistent speed

Increased `pixel-multiplier` to start with bigger chunks