### PR TITLE
Camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,4 @@ Payload (in order):
 
 - Install Java JRE or JDK from [Oracle's website](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
 - `brew install leiningen` (or install it for your OS using [these instructions](http://leiningen.org/))
+- Imagesnap `brew install imagesnap` (or install it from [here](http://iharder.sourceforge.net/current/macosx/imagesnap/))

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,8 @@
                  [org.clojure/data.json "0.2.6"]
                  [net.mikera/core.matrix "0.47.0"]
                  [org.clojure/tools.cli "0.3.3"]
+                 [vision "1.0.0-SNAPSHOT"]
                  ]
 
-  :jvm-opts ["-Xmx1G"]
+  :jvm-opts ["-Xmx1G" "-Djna.library.path=/~/work/vision/resources/lib"]
   :main fraqture.core)

--- a/src/fraqture/photo_countdown.clj
+++ b/src/fraqture/photo_countdown.clj
@@ -1,7 +1,8 @@
 (ns fraqture.photo-countdown
   (:require [fraqture.drawing]
             [quil.core :as q]
-            [fraqture.led-array :as led])
+            [fraqture.led-array :as led]
+            [clojure.java.shell :as shell])
   (:import  [fraqture.drawing Drawing]))
 
 (defn setup [options]
@@ -14,10 +15,13 @@
 
 (def vertical-line-offset 176)
 
+(defn now [] (System/currentTimeMillis))
+
 (defn draw-state [state]
   (apply q/background (:background-color state))
   (q/fill 255 255 255)
   (q/text-size 512)
+  (q/delay-frame 1000)
   (q/text-align :center :center)
   (let [options (:options state)
         serial  (:serial options)
@@ -25,10 +29,13 @@
         center-height (/ (q/height) 2)]
     (if (> (:time-left state) 0)
       (q/text (str (:time-left state)) center-width center-height))
-    (if (< (:time-left state) 0)
-      (led/paint-window serial 0 0 led/row-count led/col-count [255 255 255]))
+    (if (< (:time-left state) 1)
+      (do (led/paint-window serial 0 0 led/row-count led/col-count [255 255 255])))
     (led/refresh serial)
-    (q/delay-frame 1000)))
+
+    (if (= (:time-left state) -1)
+      (shell/sh "imagesnap" (str "images/" (now) ".jpg")))
+    ))
 
 (defn exit?
   [state]

--- a/src/fraqture/photo_countdown.clj
+++ b/src/fraqture/photo_countdown.clj
@@ -29,12 +29,13 @@
         center-height (/ (q/height) 2)]
     (if (> (:time-left state) 0)
       (q/text (str (:time-left state)) center-width center-height))
-    (if (< (:time-left state) 0)
-      (do (led/paint-window serial 0 0 led/row-count led/col-count [255 255 255])))
+    (when (< (:time-left state) 1)
+      (q/text "" center-width center-height)
+      (led/paint-window serial 0 0 led/row-count led/col-count [255 255 255]))
     (led/refresh serial)
 
     (if (= (:time-left state) -1)
-      (shell/sh "imagesnap" (str "images/" (now) ".jpg")))
+      (shell/sh "imagesnap" "-w" "1 " (str "images/" (now) ".jpg")))
     ))
 
 (defn exit?

--- a/src/fraqture/photo_countdown.clj
+++ b/src/fraqture/photo_countdown.clj
@@ -29,7 +29,7 @@
         center-height (/ (q/height) 2)]
     (if (> (:time-left state) 0)
       (q/text (str (:time-left state)) center-width center-height))
-    (if (< (:time-left state) 1)
+    (if (< (:time-left state) 0)
       (do (led/paint-window serial 0 0 led/row-count led/col-count [255 255 255])))
     (led/refresh serial)
 

--- a/src/fraqture/photo_countdown.clj
+++ b/src/fraqture/photo_countdown.clj
@@ -24,13 +24,15 @@
         center-width (/ (q/width) 2)
         center-height (/ (q/height) 2)]
     (if (> (:time-left state) 0)
-      (q/text (str (:time-left state)) center-width center-height)
+      (q/text (str (:time-left state)) center-width center-height))
+    (if (< (:time-left state) 0)
       (led/paint-window serial 0 0 led/row-count led/col-count [255 255 255]))
+    (led/refresh serial)
     (q/delay-frame 1000)))
 
 (defn exit?
   [state]
-  (< (:time-left state) -1))
+  (< (:time-left state) -2))
 
 (def drawing
   (Drawing. "Photo Countdown" setup update-state draw-state nil exit? nil))

--- a/src/fraqture/photo_countdown.clj
+++ b/src/fraqture/photo_countdown.clj
@@ -31,8 +31,8 @@
       (q/text (str (:time-left state)) center-width center-height))
     (when (< (:time-left state) 1)
       (q/text "" center-width center-height)
-      (led/paint-window serial 0 0 led/row-count led/col-count [255 255 255]))
-    (led/refresh serial)
+      (led/paint-window serial 0 0 led/row-count led/col-count [255 255 255])
+      (led/refresh serial))
 
     (if (= (:time-left state) -1)
       (shell/sh "imagesnap" "-w" "1 " (str "images/" (now) ".jpg")))


### PR DESCRIPTION
### Why?
Addresses https://github.com/smashingboxes/fraqture/issues/49

### What Changed?
Added live camera integration via `imagesnap`
Snapshots are stored in `/images` and automatically enter the cycle